### PR TITLE
Fix for HASS Recorder errors about not being JSON serializable

### DIFF
--- a/elkm1/elements.py
+++ b/elkm1/elements.py
@@ -55,6 +55,12 @@ class Element:
         varstr = ' '.join("%s:%s" % item for item in varlist)
         return "{} '{}' {}".format(self._index, self.name, varstr)
 
+    def as_dict(self):
+        cdict = self.__dict__.copy()
+        del cdict['_elk']
+        del cdict['_callbacks']
+        return cdict
+
 class Elements:
     """Base for list of elements."""
     def __init__(self, elk, class_, max_elements):


### PR DESCRIPTION
Finally stumbled upon the solution. I still don't know WHY it's necessary, but this fixes the errors like:

```
ERROR (Recorder) [homeassistant.components.recorder.util] Error executing query: Object of type 'Panel' is not JSON serializable
```

The actual element to cause the error seems to be random at each start (likely due to the intentionally unsorted and non-deterministic nature of Python lists/dicts) and it breaks the history graphs for all things in the UI frontend (I assume because it's broken in the backend) not just for the Elk stuff.

I had the same problem on my original Elk library and never got around to solving it before switching to yours. It has something to do with non-serializable data ending up in the platform discovery data somehow... finally got clued in by https://github.com/home-assistant/home-assistant/issues/8551 and a look at amcrest library code 