### PR TITLE
Add ability to find configured elements

### DIFF
--- a/elkm1_lib/elements.py
+++ b/elkm1_lib/elements.py
@@ -15,11 +15,17 @@ class Element:
         self._callbacks = []
         self.name = self.default_name()
         self._changeset = {}
+        self._configured = False
 
     @property
     def index(self):
         """Get the index, immutable once class created"""
         return self._index
+
+    @property
+    def configured(self):
+        """If a callback has ever been triggered this will be true."""
+        return self._configured
 
     def add_callback(self, callback):
         """Callbacks when attribute of element changes"""
@@ -32,6 +38,7 @@ class Element:
 
     def _call_callbacks(self):
         """Callbacks when attribute of element changes"""
+        self._configured = True
         for callback in self._callbacks:
             callback(self, self._changeset)
         self._changeset = {}

--- a/elkm1_lib/panel.py
+++ b/elkm1_lib/panel.py
@@ -26,6 +26,8 @@ class Panel(Element):
         self._elk.add_handler("SS", self._ss_handler)
         self._elk.send(vn_encode())
         self._elk.send(lw_encode())
+        # We always send ss last so we know when
+        # the sync is completed
         self._elk.send(ss_encode())
 
     def speak_word(self, word):


### PR DESCRIPTION
Currently there is no way to tell which
elements are configured which means home assistant
creates enitites that will never be used as reported in
https://github.com/home-assistant/core/issues/31776

This change adds a `sync_complete` method that can be awaited
to know that sync is completed.  Then each element can be
checked for element.configured