### PR TITLE
Add functionality to stop the connection

### DIFF
--- a/elkm1_lib/message.py
+++ b/elkm1_lib/message.py
@@ -206,6 +206,15 @@ class MessageDecode:
             "humidity": int(msg[15:17]),
         }
 
+    def _ua_decode(self, msg):
+        """UA: Valid User Code Areas."""
+        # UA is intentially not decoded
+        # because it is used to tell when a sync
+        # is completed.  If you need to add UA
+        # support, switch _sync_complete to another
+        # unused command in elk.py
+        return {}
+
     def _vn_decode(self, msg):
         """VN: Version information."""
         elkm1_version = "{}.{}.{}".format(
@@ -505,3 +514,8 @@ def zt_encode(zone):
 def zv_encode(zone):
     """zv: Get zone voltage"""
     return MessageEncode("09zv{zone:03d}00".format(zone=zone + 1), "ZV")
+
+
+def ua_encode(code):
+    """ua: Requst valid user code areas"""
+    return MessageEncode("0Cua{code:06d}00".format(code=code), "UA")

--- a/elkm1_lib/proto.py
+++ b/elkm1_lib/proto.py
@@ -36,13 +36,20 @@ class Connection(asyncio.Protocol):
         LOG.debug("disconnected callback")
         self._transport = None
         self._cleanup()
-        self._disconnected_callback()
+        if self._disconnected_callback:
+            self._disconnected_callback()
 
     def _cleanup(self):
         self._cancel_timer()
         self._waiting_for_response = None
         self._queued_writes = []
         self._buffer = ""
+
+    def stop(self):
+        """Stop the connection from sending/receiving/reconnecting."""
+        self._transport = None
+        self._cleanup()
+        self._disconnected_callback = None
 
     def pause(self):
         """Pause the connection from sending/receiving."""


### PR DESCRIPTION
Add functionality to stop the connection
    
    * Improve the sync_complete path by switching from
    "SS" to "UA" as the command we watch for since
    "SS" can be sent unexpectedly when the elk system is in trouble
    
    * Use the new stop functionality to stop when the ElkM1 reports
    and incorrect password as the the ElkM1 has brute force protection
    built in that will lock out all logins for 15 minutes once
    an incorrect password is entered 5 times.