### PR TITLE
Improve LD handling. Remove pytz dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project follows [Semantic Versioning](https://semver.org/).
 
 ## [0.8.0] -- Pending
+- Beefed up README with error reporting.
+- Improve LD handling by simplifying and adding feature to note last_user
 
 ## [0.7.15]
 - Switch to `poetry` from `pipenv` for dependency management; allowed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project follows [Semantic Versioning](https://semver.org/).
 
-## [0.7.16] -- Pending
+## [0.8.0] -- Pending
 
 ## [0.7.15]
 - Switch to `poetry` from `pipenv` for dependency management; allowed

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Basic connection to the Elk panel:
     # Print to STDOUT
     LOG = logging.getLogger(__name__)
     logging.basicConfig(level=logging.DEBUG, format='%(message)s')
-    
+
     # Connect to elk
     elk = Elk({'url': 'elk://192.168.1.100'})
     elk.connect()
@@ -41,7 +41,7 @@ Basic connection to the Elk panel:
 ```
 
 The above will connect to the Elk panel at IP address 192.168.1.100. the `elk://`
-prefix specifies that the connect is plaintext. Alternatively, `elks://` will 
+prefix specifies that the connect is plaintext. Alternatively, `elks://` will
 connect over TLS. In this case a userid and password must be specified
 and the call to `Elk` changes to:
 
@@ -64,7 +64,7 @@ refers to, for example, zones 1-208, the library references them
 as zones 0-207. All translation from base 0 to 1 and vice-versa is
 handled internally in the `elkm1_lib.message` module.
 
-After creating the `Elk` object and connecting to the panel the 
+After creating the `Elk` object and connecting to the panel the
 library code will synchronize all the elements to the data from the Elk panel.
 
 Many Elk messages are handled by the library, caching their contents. When a
@@ -83,13 +83,13 @@ of changing elements. The following user code shows registering a callback:
 The library encodes, decodes, and processes messages to/from the
 Elk panel. All the encoding and decoding is done in `elkm1_lib.message` module.
 
-Messages received are handled with callbacks. The library 
-internally registers callbacks so that decoded messages 
+Messages received are handled with callbacks. The library
+internally registers callbacks so that decoded messages
 can be used to update an `Element`. The user of the
 library may also register callbacks. Any particular message
 may have multiple callbacks.
 
-When the message is received it is decoded 
+When the message is received it is decoded
 and some validation is done. The message handler is called
 with the fields of from the decoded message. Each type of
 message has parameters that match the message type. All handler parameters
@@ -144,9 +144,9 @@ the command line and output windows. In the output window the arrow keys
 and scrollwheel scroll the contents of the window.
 
 In the command line when running `elk -i` there are a
-number of commands. Start with `help`. Then `help <command>` for 
+number of commands. Start with `help`. Then `help <command>` for
 details on each command. In general there are commands to dump the internal
-state of elements and to invoke any of the encoders to send a message 
+state of elements and to invoke any of the encoders to send a message
 to the Elk panel.
 
 For example, `light <4, 8, 12-14` would invoke the `__str__` method
@@ -195,7 +195,11 @@ logger:
 
 Do everything in your power to trim to logs down to their smallest. One way is
 to reproduce your problem quickly so that few other logs are not generated in
-between.
+between. Another recommendation is to use the simplest configuration that you
+can think of to reproduce the problem.
+
+Can you reproduce the problem in other ways? If this is a problem that is
+being experienced while using Home Assistant try using the `Services` in `Developer Tools`.
 
 Sometime logs may have sensitive information in them. You may want to
 scan your logs for that info and "X" it out. In addition, you can send logs

--- a/elkm1_lib/areas.py
+++ b/elkm1_lib/areas.py
@@ -17,17 +17,7 @@ class Area(Element):
         self.is_exit = False
         self.timer1 = 0
         self.timer2 = 0
-        # these correspond to the most recent LD log data event
-        self.log_event = None
-        self.log_number = None
-        self.log_area = None
-        self.log_hour = None
-        self.log_minute = None
-        self.log_month = None
-        self.log_day = None
-        self.log_index = None
-        self.log_day_of_week = None
-        self.log_year = None
+        self.last_log = None
 
     def arm(self, level, code):
         """(Helper) Arm system at specified level (away, vacation, etc)"""
@@ -84,19 +74,10 @@ class Areas(Elements):
         area.setattr("timer2", timer2, False)
         area.setattr("is_exit", is_exit, True)
 
-    # note the LD message are only output by the system when
-    # the G29 "Special" global setting "Event log" checkbox is set
-    def _ld_handler(
-        self, event, number, area, hour, minute, month, day, index, day_of_week, year
-    ):
-        a = self.elements[area]
-        a.setattr("log_event", event, False)
-        a.setattr("log_number", number, False)
-        a.setattr("log_area", area, False)
-        a.setattr("log_hour", hour, False)
-        a.setattr("log_minute", minute, False)
-        a.setattr("log_month", month, False)
-        a.setattr("log_day", day, False)
-        a.setattr("log_index", index, False)
-        a.setattr("log_day_of_week", day_of_week, False)
-        a.setattr("log_year", year, True)
+    # ElkM1 global setting G35 must be set for LD messages to be sent
+    def _ld_handler(self, area, log):
+        if log["event"] in [1173, 1174]:
+            # arm/disarm log (YAGNI - decode number for more log types when needed)
+            log["user_number"] = log["number"]
+        breakpoint();
+        self.elements[area].setattr("last_log", log, True)

--- a/elkm1_lib/keypads.py
+++ b/elkm1_lib/keypads.py
@@ -1,5 +1,4 @@
 """Definition of an ElkM1 Keypad."""
-import pytz
 import datetime as dt
 
 from .const import Max, TextDescriptions
@@ -14,7 +13,7 @@ class Keypad(Element):
         super().__init__(index, elk)
         self.area = -1
         self.temperature = -40
-        self.last_user_time = dt.datetime.now(pytz.UTC)
+        self.last_user_time = dt.datetime.now(dt.timezone.utc)
         self.last_user = -1
         self.code = ""
         self.last_keypress = None
@@ -41,7 +40,7 @@ class Keypads(Elements):
         keypad_ = self.elements[keypad]
 
         # By setting a time this will force the IC change to always be reported
-        keypad_.setattr("last_user_time", dt.datetime.now(pytz.UTC), False)
+        keypad_.setattr("last_user_time", dt.datetime.now(dt.timezone.utc), False)
 
         # If user is negative then invalid code entered
         keypad_.setattr("code", code if user < 0 else "****", False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "elkm1-lib"
-version = "0.7.19"
+version = "0.8.0"
 description = "Library for interacting with ElkM1 alarm/automation panel."
 homepage = "https://github.com/gwww/elkm1"
 authors = ["Glenn Waters <gwwaters+elkm1@gmail.com>"]
@@ -15,7 +15,6 @@ exclude = ["test"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
-pytz = ">= 2018.9"
 pyserial-asyncio = "^0.4.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
    LD handling simplified. Time now represented as ISO string rather
    than a set of values.

    `user_number` saved for arm/disarm logs. This will be used with
    the HA integration.

    keypads.py used to depend on pytz, removed in favour of using
    datetime TZ handling - functionally equivalent.