### PR TITLE
Clean code: moving responsibilites closer to the right spot

### DIFF
--- a/elkm1_lib/counters.py
+++ b/elkm1_lib/counters.py
@@ -31,8 +31,8 @@ class Counters(Elements):
         """Retrieve values from ElkM1 on demand"""
         self.get_descriptions(TextDescriptions.COUNTER.value)
 
-    def _got_desc(self, descriptions):
-        super()._got_desc(descriptions)
+    def _got_desc(self, descriptions, desc_type):
+        super()._got_desc(descriptions, desc_type)
         # Only poll counters that have a name defined
         for counter in self.elements:
             if not counter.is_default_name():

--- a/elkm1_lib/elements.py
+++ b/elkm1_lib/elements.py
@@ -126,7 +126,7 @@ class Elements:
                 if user_re and user_re.match(name):
                     continue
                 element.setattr("name", name, True)
-                element._configured = True
+                element._configured = True  # pylint: disable=protected-access
 
     def get_descriptions(self, description_type):
         """Gets the descriptions for specified type."""

--- a/elkm1_lib/elements.py
+++ b/elkm1_lib/elements.py
@@ -5,6 +5,7 @@
 import re
 from abc import abstractmethod
 
+from .const import TextDescriptions
 from .message import sd_encode
 
 
@@ -105,18 +106,19 @@ class Elements:
             return
 
         if unit < 0 or unit >= count:
-            callback(results)
+            callback(results, desc_type)
             self._get_description_state = None
         else:
             results[unit] = desc
             self.elk.send(sd_encode(desc_type, unit + 1))
 
-    def _got_desc(self, descriptions):
-        from .users import Users
-
+    def _got_desc(self, descriptions, desc_type):
         # Elk reports descriptions for all 199 users, irregardless of how many
-        # are configured. Don't set their name and configured flag.
-        user_re = re.compile(r"USER \d\d\d") if isinstance(self, Users) else None
+        # are configured. Only set configured for those that are really there.
+        if desc_type == TextDescriptions.USER.value[0]:
+            user_re = re.compile(r"USER \d\d\d")
+        else:
+            user_re = None
 
         for element in self.elements:
             if element.index >= len(descriptions):

--- a/elkm1_lib/elements.py
+++ b/elkm1_lib/elements.py
@@ -84,7 +84,6 @@ class Elements:
         self.elk = elk
         self.max_elements = max_elements
         self.elements = [class_(i, elk) for i in range(max_elements)]
-        self.elk.add_sync_handler(self.sync)
 
     def __iter__(self):
         for element in self.elements:

--- a/elkm1_lib/elk.py
+++ b/elkm1_lib/elk.py
@@ -142,7 +142,7 @@ class Elk:  # pylint: disable=too-many-instance-attributes
         except (ValueError, AttributeError) as exc:
             if not data:
                 return
-            if data.startswith("Username: ") or data.startswith("Password: ")
+            if data.startswith("Username: ") or data.startswith("Password: "):
                 return
 
             if data.startswith("Username/Password not found"):

--- a/elkm1_lib/elk.py
+++ b/elkm1_lib/elk.py
@@ -21,14 +21,12 @@ class Elk:  # pylint: disable=too-many-instance-attributes
         """Initialize a new Elk instance."""
         self.loop = loop if loop else asyncio.get_event_loop()
         self._config = config
-        self._conn = None
-        self._transport = None
-        self._connection_retry_timer = 1
+        self._connection = None
+        self._connection_retry_time = 1
         self._message_decode = MessageDecode()
         self._sync_event = asyncio.Event()
         self._invalid_auth = False
         self._reconnect_task = None
-        self._disconnect_requested = False
 
         self.connected_callback = None
         self.disconnected_callback = None
@@ -69,7 +67,7 @@ class Elk:  # pylint: disable=too-many-instance-attributes
         scheme, dest, param, ssl_context = parse_url(url)
         heartbeat_time = 120 if not scheme == "serial" else -1
 
-        conn = partial(
+        connection = partial(
             Connection,
             self.loop,
             heartbeat_time,
@@ -81,42 +79,44 @@ class Elk:  # pylint: disable=too-many-instance-attributes
         try:
             if scheme == "serial":
                 await serial_asyncio.create_serial_connection(
-                    self.loop, conn, dest, baudrate=param
+                    self.loop, connection, dest, baudrate=param
                 )
             else:
                 await asyncio.wait_for(
                     self.loop.create_connection(
-                        conn, host=dest, port=param, ssl=ssl_context
+                        connection, host=dest, port=param, ssl=ssl_context
                     ),
                     timeout=30,
                 )
         except (ValueError, OSError, asyncio.TimeoutError) as err:
-            if self._disconnect_requested:
-                # disconnect called while trying to reconnect
+            if self._connection_retry_time <= 0:
                 return
+
             LOG.warning(
                 "Could not connect to ElkM1 (%s). Retrying in %d seconds",
                 err,
-                self._connection_retry_timer,
+                self._connection_retry_time,
             )
-            self._reconnect_task = self.loop.call_later(
-                self._connection_retry_timer, self._reconnect
-            )
-            self._connection_retry_timer = (
-                2 * self._connection_retry_timer
-                if self._connection_retry_timer < 32
-                else 60
-            )
+            self._start_connection_retry_timer()
 
-    def _connected(self, transport, conn):
+    def _start_connection_retry_timer(self):
+        if self._connection_retry_time > 0:
+            self._reconnect_task = self.loop.call_later(
+                self._connection_retry_time, self._reconnect
+            )
+            if self._connection_retry_time < 32:
+                self._connection_retry_time *= 2
+            else:
+                self._connection_retry_time = 60
+
+    def _connected(self, connection):
         """Login and sync the ElkM1 panel to memory."""
         LOG.info("Connected to ElkM1")
-        self._conn = conn
-        self._transport = transport
-        self._connection_retry_timer = 1
+        self._connection = connection
+        self._connection_retry_time = 1
         if url_scheme_is_secure(self._config["url"]):
-            self._conn.write_data(self._config["userid"], raw=True)
-            self._conn.write_data(self._config["password"], raw=True)
+            self._connection.write_data(self._config["userid"], raw=True)
+            self._connection.write_data(self._config["password"], raw=True)
         self.call_sync_handlers()
         if self.connected_callback:
             self.connected_callback(self)
@@ -126,10 +126,8 @@ class Elk:  # pylint: disable=too-many-instance-attributes
 
     def _disconnected(self):
         LOG.warning("ElkM1 at %s disconnected", self._config["url"])
-        self._conn = None
-        self._reconnect_task = self.loop.call_later(
-            self._connection_retry_timer, self._reconnect
-        )
+        self._connection = None
+        self._start_connection_retry_timer()
         if self.disconnected_callback:
             self.disconnected_callback(self)
 
@@ -141,12 +139,10 @@ class Elk:  # pylint: disable=too-many-instance-attributes
         LOG.debug("got_data '%s'", data)
         try:
             self._message_decode.decode(data)
-        except (ValueError, AttributeError) as err:
-            if (
-                not data
-                or data.startswith("Username: ")
-                or data.startswith("Password: ")
-            ):
+        except (ValueError, AttributeError) as exc:
+            if not data:
+                return
+            if data.startswith("Username: ") or data.startswith("Password: ")
                 return
 
             if data.startswith("Username/Password not found"):
@@ -156,9 +152,8 @@ class Elk:  # pylint: disable=too-many-instance-attributes
                 self._sync_event.set()
             elif "Login successful" in data:
                 LOG.info("Successful login.")
-                return
-
-            LOG.debug(err)
+            else:
+                LOG.exception("Invalid message '%s'", data, exc)
 
     def _timeout(self, msg_code):
         self._message_decode.timeout_handler(msg_code)
@@ -178,11 +173,10 @@ class Elk:  # pylint: disable=too-many-instance-attributes
 
     def is_connected(self):
         """Status of connection to Elk."""
-        return self._conn is not None
+        return self._connection is not None
 
     def connect(self, connected_callback=None, disconnected_callback=None):
         """Connect to the panel"""
-        self._disconnect_requested = False
         self.connected_callback = connected_callback
         self.disconnected_callback = disconnected_callback
         asyncio.ensure_future(self._connect())
@@ -193,31 +187,28 @@ class Elk:  # pylint: disable=too-many-instance-attributes
 
     def send(self, msg):
         """Send a message to Elk panel."""
-        if self._conn:
-            self._conn.write_data(msg.message, msg.response_command)
+        if self._connection:
+            self._connection.write_data(msg.message, msg.response_command)
 
     def pause(self):
         """Pause the connection from sending/receiving."""
-        if self._conn:
-            self._conn.pause()
+        if self._connection:
+            self._connection.pause()
 
     def resume(self):
         """Restart the connection from sending/receiving."""
-        if self._conn:
-            self._conn.resume()
+        if self._connection:
+            self._connection.resume()
 
     def disconnect(self):
         """Disconnect the connection from sending/receiving."""
-        self._disconnect_requested = True
-        if self._conn:
-            self._conn.stop()
-            self._conn = None
+        self._connection_retry_time = -1
+        if self._connection:
+            self._connection.close()
+            self._connection = None
         if self._reconnect_task:
             self._reconnect_task.cancel()
             self._reconnect_task = None
-        if self._transport:
-            self._transport.close()
-            self._transport = None
 
     @property
     def invalid_auth(self):

--- a/elkm1_lib/message.py
+++ b/elkm1_lib/message.py
@@ -44,7 +44,7 @@ class MessageDecode:
 
     def decode(self, msg):
         """Decode an Elk message by passing to appropriate decoder"""
-        invalid = _is_message_valid(msg)
+        invalid = _is_valid_length_and_checksum(msg)
         if invalid:
             if msg.startswith("Username: ") or msg.startswith("Password: "):
                 return
@@ -345,7 +345,7 @@ def _status_decode(status):
     return (logical_status, physical_status)
 
 
-def _is_message_valid(msg):
+def _is_valid_length_and_checksum(msg):
     """Check packet length valid and that checksum is good."""
     try:
         if int(msg[:2], 16) != (len(msg) - 2):

--- a/elkm1_lib/panel.py
+++ b/elkm1_lib/panel.py
@@ -18,20 +18,18 @@ class Panel(Element):
         self.remote_programming_status = 0
         self.system_trouble_status = ""
         self.setattr("name", "ElkM1", True)
-        self._elk.add_sync_handler(self.sync)
 
-    def sync(self):
-        """Retrieve panel information from ElkM1"""
         self._elk.add_handler("VN", self._vn_handler)
         self._elk.add_handler("XK", self._xk_handler)
         self._elk.add_handler("RR", self._xk_handler)  # RR/XK use same handler
         self._elk.add_handler("RP", self._rp_handler)
         self._elk.add_handler("IE", self._elk.call_sync_handlers)
         self._elk.add_handler("SS", self._ss_handler)
+
+    def sync(self):
+        """Retrieve panel information from ElkM1"""
         self._elk.send(vn_encode())
         self._elk.send(lw_encode())
-        # We always send ss last so we know when
-        # the sync is completed
         self._elk.send(ss_encode())
 
     def speak_word(self, word):

--- a/elkm1_lib/proto.py
+++ b/elkm1_lib/proto.py
@@ -33,7 +33,7 @@ class Connection(asyncio.Protocol):  # pylint: disable=too-many-instance-attribu
     def connection_made(self, transport):
         LOG.debug("connected callback")
         self._transport = transport
-        self._connected_callback(transport, self)
+        self._connected_callback(self)
 
     def connection_lost(self, exc):
         LOG.debug("disconnected callback")
@@ -48,11 +48,12 @@ class Connection(asyncio.Protocol):  # pylint: disable=too-many-instance-attribu
         self._queued_writes = []
         self._buffer = ""
 
-    def stop(self):
+    def close(self):
         """Stop the connection from sending/receiving/reconnecting."""
-        self._transport = None
+        if self._transport:
+            self._transport.close()
+            self._transport = None
         self._cleanup()
-        self._disconnected_callback = None
 
     def pause(self):
         """Pause the connection from sending/receiving."""

--- a/elkm1_lib/thermostats.py
+++ b/elkm1_lib/thermostats.py
@@ -34,8 +34,8 @@ class Thermostats(Elements):
         """Retrieve areas from ElkM1"""
         self.get_descriptions(TextDescriptions.THERMOSTAT.value)
 
-    def _got_desc(self, descriptions):
-        super()._got_desc(descriptions)
+    def _got_desc(self, descriptions, desc_type):
+        super()._got_desc(descriptions, desc_type)
         # Only poll thermostats that have a name defined
         for thermostat in self.elements:
             if not thermostat.is_default_name():

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -53,21 +53,44 @@ def test_decode_raises_value_error_on_length_too_long():
     decoder = m.MessageDecode()
     with pytest.raises(ValueError) as excinfo:
         decoder.decode("42CV01000990030")
-    assert str(excinfo.value) == "Elk message length incorrect"
+    assert str(excinfo.value) == "Incorrect message length"
 
 
 def test_decode_raises_value_error_on_length_too_short():
     decoder = m.MessageDecode()
     with pytest.raises(ValueError) as excinfo:
         decoder.decode("02CV01000990030")
-    assert str(excinfo.value) == "Elk message length incorrect"
+    assert str(excinfo.value) == "Incorrect message length"
 
 
 def test_decode_raises_value_error_on_bad_checksum():
     decoder = m.MessageDecode()
     with pytest.raises(ValueError) as excinfo:
         decoder.decode("0DCV01000990042")
-    assert str(excinfo.value) == "Elk message checksum invalid"
+    assert str(excinfo.value) == "Bad checksum"
+
+
+def test_decode_raises_value_error_on_short_message():
+    decoder = m.MessageDecode()
+    with pytest.raises(ValueError) as excinfo:
+        decoder.decode("")
+    assert str(excinfo.value) == "Message invalid"
+
+
+def test_decode_login_success():
+    mock_login_success_handler = Mock()
+    decoder = m.MessageDecode()
+    decoder.add_handler("login_success", mock_login_success_handler)
+    decoder.decode("Login successful")
+    mock_login_success_handler.assert_called_once_with()
+
+
+def test_decode_login_failed():
+    mock_login_failed_handler = Mock()
+    decoder = m.MessageDecode()
+    decoder.add_handler("login_failed", mock_login_failed_handler)
+    decoder.decode("Username/Password not found")
+    mock_login_failed_handler.assert_called_once_with()
 
 
 def test_encode_message_with_a_variable():

--- a/test/test_proto.py
+++ b/test/test_proto.py
@@ -7,21 +7,21 @@ from elkm1_lib.proto import Connection
 
 def test_receive_single_packet_and_pass_to_handler():
     mock_gotdata = Mock()
-    connection = Connection(None, None, None, mock_gotdata, None)
+    connection = Connection(None, 0, None, None, mock_gotdata, None)
     connection.data_received("test\r\n".encode())
     mock_gotdata.assert_called_once_with("test")
 
 
 def test_receive_multiple_packets():
     mock_gotdata = Mock()
-    connection = Connection(None, None, None, mock_gotdata, None)
+    connection = Connection(None, 0, None, None, mock_gotdata, None)
     connection.data_received("test1\r\ntest2\r\n".encode())
     mock_gotdata.assert_has_calls([call("test1"), call("test2")])
 
 
 def test_received_full_packet_and_partial_packet():
     mock_gotdata = Mock()
-    connection = Connection(None, None, None, mock_gotdata, None)
+    connection = Connection(None, 0, None, None, mock_gotdata, None)
     connection.data_received("test1\r\nfirst-bit,".encode())
     mock_gotdata.assert_called_once_with("test1")
 
@@ -30,7 +30,7 @@ def test_received_full_packet_and_partial_packet():
 
 
 def test_write_simple():
-    connection = Connection(None, None, None, None, None)
+    connection = Connection(None, 0, None, None, None, None)
     connection._transport = Mock()
     connection.write_data("08cv0900")
     connection._transport.write.assert_called_once_with("08cv0900F6\r\n".encode())


### PR DESCRIPTION
Lots of description in the individual commits. This is a couple of things:
- Refactoring names to be better suited to what they are
- Moving pieces of code around so that the code is closer to where the responsibility lies
  - Moved heartbeat into proto
  - Moved decode of username/password into message
  - Moved description handling into elements
- Simplified a couple of flags; removed disconnect_requested for example