### PR TITLE
Remove extra buffering layer since its already handled by asyncio

### DIFF
--- a/elkm1_lib/connection.py
+++ b/elkm1_lib/connection.py
@@ -10,7 +10,7 @@ from typing import Optional, cast
 
 import serial_asyncio
 
-from .message import MessageEncode, decode, get_elk_command
+from .message import MessageEncode, decode
 from .notify import Notifier
 from .util import parse_url
 


### PR DESCRIPTION
We shouldn't need to hold back writes since WriteTransport already does this.

https://github.com/python/cpython/blob/fd9bdde769f371f6824d6dbe724db4b3ba9831ad/Lib/asyncio/selector_events.py#L929

This speeds up startup for me quite a bit going from 47s to 17s
