### PR TITLE
Disable buffering after login is complete

### DIFF
--- a/elkm1_lib/elk.py
+++ b/elkm1_lib/elk.py
@@ -82,6 +82,7 @@ class Elk:
             LOG.error("Invalid username or password.")
 
     def _got_first_message(self, **kwargs: dict[str, Any]) -> None:
+        self._connection.login_completed()
         if not self._logged_in:
             self._notifier.notify("login", {"succeeded": True})
 


### PR DESCRIPTION
Replaces #65 since we can't hand off buffering to asyncio until after the login is completed since it seems that the stream isn't fully connected on the elk until the login is complete

We shouldn't need to hold back writes since WriteTransport already does this.

https://github.com/python/cpython/blob/fd9bdde769f371f6824d6dbe724db4b3ba9831ad/Lib/asyncio/selector_events.py#L929

This speeds up startup for me quite a bit going from 47s to 18s