### PR TITLE
Replace ssl.PROTOCOL_TLS

### DIFF
--- a/elkm1_lib/util.py
+++ b/elkm1_lib/util.py
@@ -32,7 +32,7 @@ def ssl_context_for_scheme(scheme: str) -> ssl.SSLContext:
     Since ssl context is expensive to create, cache it
     for future use since we only have a few schemes.
     """
-    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     if tls := TLS_VERSIONS.get(scheme):
         ssl_context.minimum_version = tls
         ssl_context.maximum_version = tls


### PR DESCRIPTION
`ssl.PROTOCOL_TLS` is deprecated in favor of `ssl.PROTOCOL_TLS_CLIENT` and `ssl.PROTOCOL_TLS_SERVER`.
https://docs.python.org/3.11/library/ssl.html#ssl.PROTOCOL_TLS