### PR TITLE
Update ssl context construction for py3.12 compatibility

### DIFF
--- a/elkm1_lib/util.py
+++ b/elkm1_lib/util.py
@@ -32,11 +32,12 @@ def ssl_context_for_scheme(scheme: str) -> ssl.SSLContext:
     Since ssl context is expensive to create, cache it
     for future use since we only have a few schemes.
     """
-    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     if tls := TLS_VERSIONS.get(scheme):
         ssl_context.minimum_version = tls
         ssl_context.maximum_version = tls
 
+    ssl_context.verify_mode = ssl.CERT_NONE
     ssl_context.set_ciphers("DEFAULT:@SECLEVEL=0")
 
     # ssl.OP_LEGACY_SERVER_CONNECT is only available in Python 3.12a4+

--- a/elkm1_lib/util.py
+++ b/elkm1_lib/util.py
@@ -37,6 +37,7 @@ def ssl_context_for_scheme(scheme: str) -> ssl.SSLContext:
         ssl_context.minimum_version = tls
         ssl_context.maximum_version = tls
 
+    ssl_context.check_hostname = False
     ssl_context.verify_mode = ssl.CERT_NONE
     ssl_context.set_ciphers("DEFAULT:@SECLEVEL=0")
 


### PR DESCRIPTION
replaces and closes #71