### PR TITLE
Remove async-timeout dependency

### DIFF
--- a/elkm1_lib/connection.py
+++ b/elkm1_lib/connection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
+from asyncio import timeout as asyncio_timeout
 from collections import deque
 from functools import reduce
 from typing import Any, NamedTuple
@@ -14,12 +14,6 @@ from serial_asyncio_fast import open_serial_connection
 from .message import MessageEncode, decode, get_elk_command
 from .notify import Notifier
 from .util import parse_url
-
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout  # pyright: ignore
-else:
-    from asyncio import timeout as asyncio_timeout  # pyright: ignore
-
 
 LOG = logging.getLogger(__name__)
 HEARTBEAT_TIME = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
 ]
 dependencies = [
     "pyserial-asyncio-fast >= 0.14",
-    "async-timeout >= 4.0",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -15,15 +15,6 @@ wheels = [
 ]
 
 [[package]]
-name = "async-timeout"
-version = "4.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/d6/21b30a550dafea84b1b8eee21b5e23fa16d010ae006011221f33dcd8d7f8/async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f", size = 8345 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028", size = 5721 },
-]
-
-[[package]]
 name = "attrs"
 version = "24.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -67,7 +58,6 @@ name = "elkm1-lib"
 version = "2.2.7"
 source = { editable = "." }
 dependencies = [
-    { name = "async-timeout" },
     { name = "pyserial-asyncio-fast" },
 ]
 
@@ -84,10 +74,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "async-timeout", specifier = ">=4.0" },
-    { name = "pyserial-asyncio-fast", specifier = ">=0.14" },
-]
+requires-dist = [{ name = "pyserial-asyncio-fast", specifier = ">=0.14" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
It is supplied by default in Python 3.11